### PR TITLE
Modify replay filenames to avoid collisions

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -698,12 +698,15 @@ async def api_get_replay(
     the player's total replay views.
     """
     # fetch replay file & make sure it exists
-    replay_file = REPLAYS_PATH / f"{score_id}.osr"
+    # try official replay first, then custom replay
+    replay_file = REPLAYS_PATH / f"{score_id}1.osr"
     if not replay_file.exists():
-        return ORJSONResponse(
-            {"status": "Replay not found."},
-            status_code=status.HTTP_404_NOT_FOUND,
-        )
+        replay_file = REPLAYS_PATH / f"{score_id}2.osr"
+        if not replay_file.exists():
+            return ORJSONResponse(
+                {"status": "Replay not found."},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
     # read replay frames from file
     raw_replay_data = replay_file.read_bytes()
     if not include_headers:


### PR DESCRIPTION
## Summary
- separate official vs custom replays by suffixing score id with `1` or `2`
- update replay retrieval logic to check these new filenames

## Testing
- `pre-commit run --files app/api/domains/osu.py app/api/v1/api.py` *(fails: failed to find interpreter for python3.11)*
- `pytest -q` *(fails: Can't connect to MySQL server on 'mysql')*

------
https://chatgpt.com/codex/tasks/task_e_68794bff6d5c83319c5b7c5d5ab881fb