### PR TITLE
Modify replay filenames to avoid collisions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,11 @@ TUNNEL_TOKEN=CloudflaredTunnelToken
 ##          read through what it enables.
 ##          you could put your server at risk.
 DEVELOPER_MODE=False
+
+# Object storage (S3 compatible)
+S3_ENDPOINT=http://localhost:9000
+S3_ACCESS_KEY=your_access_key
+S3_SECRET_KEY=your_secret_key
+S3_REGION=us-east-1
+S3_REPLAY_BUCKET=replays
+S3_OSU_BUCKET=osu-files

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -48,6 +48,7 @@ import app.settings
 import app.state
 import app.state.services
 import app.utils
+import app.storage
 from app import encryption
 from app._typing import UNSET
 from app.constants import regexes
@@ -919,8 +920,8 @@ async def handle_custom_map_score_submission(
         MIN_REPLAY_SIZE = 24
 
         if len(replay_data) >= MIN_REPLAY_SIZE:
-            replay_disk_file = REPLAYS_PATH / f"custom_{score.id}.osr"
-            replay_disk_file.write_bytes(replay_data)
+            key = f"{score.id}2.osr"
+            await app.storage.upload(app.settings.S3_REPLAY_BUCKET, key, replay_data)
 
     # 更新用户统计 - 完全与官方谱面保持一致
     if score.player.stats is None:
@@ -1503,8 +1504,8 @@ async def osuSubmitModularSelector(
         MIN_REPLAY_SIZE = 24
 
         if len(replay_data) >= MIN_REPLAY_SIZE:
-            replay_disk_file = REPLAYS_PATH / f"{score.id}.osr"
-            replay_disk_file.write_bytes(replay_data)
+            key = f"{score.id}1.osr"
+            await app.storage.upload(app.settings.S3_REPLAY_BUCKET, key, replay_data)
         else:
             log(f"{score.player} submitted a score without a replay!", Ansi.LRED)
 
@@ -1781,18 +1782,20 @@ async def getReplay(
     score_id: int = Query(..., alias="c", min=0, max=9_223_372_036_854_775_807),
 ) -> Response:
     score = await Score.from_sql(score_id)
-    if not score:
+    if score is not None:
+        key = f"{score_id}1.osr"
+    else:
+        key = f"{score_id}2.osr"
+
+    data = await app.storage.download(app.settings.S3_REPLAY_BUCKET, key)
+    if data is None:
         return Response(b"", status_code=404)
 
-    file = REPLAYS_PATH / f"{score_id}.osr"
-    if not file.exists():
-        return Response(b"", status_code=404)
-
-    # increment replay views for this score
-    if score.player is not None and player.id != score.player.id:
+    # increment replay views for this score (official scores only)
+    if score is not None and score.player is not None and player.id != score.player.id:
         app.state.loop.create_task(score.increment_replay_views())  # type: ignore[unused-awaitable]
 
-    return FileResponse(file)
+    return Response(data, media_type="application/octet-stream")
 
 
 @router.get("/web/osu-rate.php")

--- a/app/settings.py
+++ b/app/settings.py
@@ -70,5 +70,13 @@ LOG_WITH_COLORS = read_bool(os.environ["LOG_WITH_COLORS"])
 ##          you could put your server at risk.
 DEVELOPER_MODE = read_bool(os.environ["DEVELOPER_MODE"])
 
+# object storage
+S3_ENDPOINT = os.environ["S3_ENDPOINT"]
+S3_ACCESS_KEY = os.environ["S3_ACCESS_KEY"]
+S3_SECRET_KEY = os.environ["S3_SECRET_KEY"]
+S3_REGION = os.environ.get("S3_REGION", "us-east-1")
+S3_REPLAY_BUCKET = os.environ["S3_REPLAY_BUCKET"]
+S3_OSU_BUCKET = os.environ["S3_OSU_BUCKET"]
+
 with open("pyproject.toml", "rb") as f:
     VERSION = tomllib.load(f)["tool"]["poetry"]["version"]

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import boto3
+
+import app.settings
+
+s3_client = boto3.client(
+    "s3",
+    endpoint_url=app.settings.S3_ENDPOINT,
+    aws_access_key_id=app.settings.S3_ACCESS_KEY,
+    aws_secret_access_key=app.settings.S3_SECRET_KEY,
+    region_name=app.settings.S3_REGION,
+)
+
+async def upload(bucket: str, key: str, data: bytes) -> None:
+    await asyncio.to_thread(
+        s3_client.put_object, Bucket=bucket, Key=key, Body=data
+    )
+
+async def download(bucket: str, key: str) -> Optional[bytes]:
+    def _get() -> bytes:
+        resp = s3_client.get_object(Bucket=bucket, Key=key)
+        return resp["Body"].read()
+
+    try:
+        return await asyncio.to_thread(_get)
+    except s3_client.exceptions.ClientError as exc:  # type: ignore[attr-defined]
+        if exc.response.get("Error", {}).get("Code") in {"NoSuchKey", "404"}:
+            return None
+        raise
+
+async def exists(bucket: str, key: str) -> bool:
+    try:
+        await asyncio.to_thread(
+            s3_client.head_object, Bucket=bucket, Key=key
+        )
+        return True
+    except s3_client.exceptions.ClientError as exc:  # type: ignore[attr-defined]
+        if exc.response.get("Error", {}).get("Code") in {"404", "NoSuchKey", "NotFound"}:
+            return False
+        raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ tzdata = "2024.1"
 coverage = "^7.4.1"
 databases = { version = "^0.8.0", extras = ["mysql"] }
 python-json-logger = "^2.0.7"
+boto3 = "1.34.93"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "3.6.1"


### PR DESCRIPTION
## Summary
- separate official vs custom replays by suffixing score id with `1` or `2`
- update replay retrieval logic to check these new filenames
- store replays and `.osu` files in S3 object storage

## Testing
- `pre-commit run --files app/storage.py app/api/domains/osu.py app/api/v1/api.py app/settings.py app/objects/beatmap.py .env.example pyproject.toml` *(fails: failed to find interpreter for python3.11)*
- `pytest -q` *(fails: ImportError while loading httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68794bff6d5c83319c5b7c5d5ab881fb