### PR TITLE
Modify replay filenames to avoid collisions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,12 @@ TUNNEL_TOKEN=CloudflaredTunnelToken
 ##          read through what it enables.
 ##          you could put your server at risk.
 DEVELOPER_MODE=False
+
+# Object storage (Cloudflare R2 compatible)
+R2_ENDPOINT=http://localhost:9000
+R2_ACCESS_KEY=your_access_key
+R2_SECRET_KEY=your_secret_key
+R2_REGION=auto
+R2_BUCKET=bancho-storage
+R2_REPLAY_FOLDER=replays
+R2_OSU_FOLDER=osu

--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -24,6 +24,7 @@ from starlette.requests import ClientDisconnect
 import app.bg_loops
 import app.settings
 import app.state
+import app.storage
 import app.utils
 from app.api import api_router  # type: ignore[attr-defined]
 from app.api import domains
@@ -93,6 +94,8 @@ async def lifespan(asgi_app: BanchoAPI) -> AsyncIterator[None]:
         app.state.services.datadog.gauge("bancho.online_players", 0)  # type: ignore[no-untyped-call]
 
     app.state.services.ip_resolver = app.state.services.IPResolver()
+
+    await app.storage.ensure_folders()
 
     await app.state.services.run_sql_migrations()
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -70,5 +70,14 @@ LOG_WITH_COLORS = read_bool(os.environ["LOG_WITH_COLORS"])
 ##          you could put your server at risk.
 DEVELOPER_MODE = read_bool(os.environ["DEVELOPER_MODE"])
 
+# object storage (Cloudflare R2)
+R2_ENDPOINT = os.environ["R2_ENDPOINT"]
+R2_ACCESS_KEY = os.environ["R2_ACCESS_KEY"]
+R2_SECRET_KEY = os.environ["R2_SECRET_KEY"]
+R2_REGION = os.environ.get("R2_REGION", "auto")
+R2_BUCKET = os.environ["R2_BUCKET"]
+R2_REPLAY_FOLDER = os.environ.get("R2_REPLAY_FOLDER", "replays")
+R2_OSU_FOLDER = os.environ.get("R2_OSU_FOLDER", "osu")
+
 with open("pyproject.toml", "rb") as f:
     VERSION = tomllib.load(f)["tool"]["poetry"]["version"]

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import asyncio
+
+import boto3
+
+import app.settings
+
+r2_client = boto3.client(
+    "s3",
+    endpoint_url=app.settings.R2_ENDPOINT,
+    aws_access_key_id=app.settings.R2_ACCESS_KEY,
+    aws_secret_access_key=app.settings.R2_SECRET_KEY,
+    region_name=app.settings.R2_REGION,
+)
+
+
+async def upload(bucket: str, key: str, data: bytes) -> None:
+    await asyncio.to_thread(r2_client.put_object, Bucket=bucket, Key=key, Body=data)
+
+
+async def download(bucket: str, key: str) -> bytes | None:
+    def _get() -> bytes:
+        resp = r2_client.get_object(Bucket=bucket, Key=key)
+        return resp["Body"].read()
+
+    try:
+        return await asyncio.to_thread(_get)
+    except r2_client.exceptions.ClientError as exc:  # type: ignore[attr-defined]
+        if exc.response.get("Error", {}).get("Code") in {"NoSuchKey", "404"}:
+            return None
+        raise
+
+
+async def exists(bucket: str, key: str) -> bool:
+    try:
+        await asyncio.to_thread(r2_client.head_object, Bucket=bucket, Key=key)
+        return True
+    except r2_client.exceptions.ClientError as exc:  # type: ignore[attr-defined]
+        if exc.response.get("Error", {}).get("Code") in {
+            "404",
+            "NoSuchKey",
+            "NotFound",
+        }:
+            return False
+        raise
+
+
+async def ensure_folders() -> None:
+    for folder in (
+        app.settings.R2_REPLAY_FOLDER,
+        app.settings.R2_OSU_FOLDER,
+    ):
+        await asyncio.to_thread(
+            r2_client.put_object,
+            Bucket=app.settings.R2_BUCKET,
+            Key=f"{folder}/",
+            Body=b"",
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ tzdata = "2024.1"
 coverage = "^7.4.1"
 databases = { version = "^0.8.0", extras = ["mysql"] }
 python-json-logger = "^2.0.7"
+boto3 = "1.34.93"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "3.6.1"


### PR DESCRIPTION
## Summary
- separate official vs custom replays by suffixing score id with `1` or `2`
- update replay retrieval logic to check these new filenames
- store data in Cloudflare R2 instead of S3
- keep osu and osr files under folders within a single R2 bucket
- ensure folders exist on startup

## Testing
- `pre-commit run --files .env.example app/settings.py app/api/domains/osu.py app/api/v1/api.py app/objects/beatmap.py app/storage.py app/api/init_api.py`
- `pytest -q` *(fails: KeyError: 'DB_HOST')*

------
https://chatgpt.com/codex/tasks/task_e_68794bff6d5c83319c5b7c5d5ab881fb